### PR TITLE
Footer points to Wordpress Address instead of Site Address

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -388,7 +388,7 @@ function fetch_copyright(){
 		jQuery(document).ready(function(){
 		var copyright_text = "<?php if (isset($responsive_options['copyright_textbox'])) { echo $responsive_options['copyright_textbox']; } ?>";
 		var cyberchimps_link = "<?php if (isset($responsive_options['poweredby_link'])) { echo $responsive_options['poweredby_link']; } ?>";
-		var siteurl = "<?php echo site_url(); ?>"; 
+		var siteurl = "<?php echo home_url(); ?>"; 
 		if(copyright_text == "")
 		{
 			jQuery(".copyright #copyright_link").text(" "+"Default copyright text");


### PR DESCRIPTION
`site_url()` returns the address of the Wordpress installation while `home_url()` returns the address of the actual site. The link in the footer should point to the address of the site.
